### PR TITLE
Fixed Canvas Scaling on Gallery Page and Image Viewer.

### DIFF
--- a/MyTestVueApp.Server/Controllers/LikeController.cs
+++ b/MyTestVueApp.Server/Controllers/LikeController.cs
@@ -112,7 +112,7 @@ namespace MyTestVueApp.Server.Controllers
             }
             else
             {
-                return BadRequest("User is not logged in!");
+                return Ok(false);
             }
         }
     }

--- a/mytestvueapp.client/src/components/Gallery/ArtCard.vue
+++ b/mytestvueapp.client/src/components/Gallery/ArtCard.vue
@@ -3,11 +3,10 @@
   <!-- Container -->
   <Card
     class="art-card flex-shrink-0 overflow-hidden border-round-md cursor-pointer p-0 gallery-card"
-    :style="{ width: 32 * size + 'px' }"
     @click="router.push(`/art/${art.id}`)"
   >
     <template #header>
-      <MyCanvas :art="art" :pixelSize="(32 / art.pixelGrid?.height) * size" />
+      <MyCanvas :art="art" :pixelSize="6.5" />
     </template>
     <template #title>
       <div class="text-base font-bold m-0 px-2 pt-1">

--- a/mytestvueapp.client/src/components/Gallery/ArtCard.vue
+++ b/mytestvueapp.client/src/components/Gallery/ArtCard.vue
@@ -35,14 +35,12 @@
 import Card from "primevue/card";
 import Button from "primevue/button";
 import LikeButton from "../LikeButton.vue";
-import { ref } from "vue";
 import MyCanvas from "../MyCanvas/MyCanvas.vue";
 import Art from "@/entities/Art";
 import router from "@/router";
 
 const props = defineProps<{
   art: Art;
-  size: number;
 }>();
 </script>
 

--- a/mytestvueapp.client/src/components/Gallery/ArtCard.vue
+++ b/mytestvueapp.client/src/components/Gallery/ArtCard.vue
@@ -6,7 +6,7 @@
     @click="router.push(`/art/${art.id}`)"
   >
     <template #header>
-      <MyCanvas :art="art" :pixelSize="6.5" />
+      <MyCanvas :art="art" :pixelSize="size" />
     </template>
     <template #title>
       <div class="text-base font-bold m-0 px-2 pt-1">
@@ -41,6 +41,7 @@ import router from "@/router";
 
 const props = defineProps<{
   art: Art;
+  size: number;
 }>();
 </script>
 

--- a/mytestvueapp.client/src/components/MyCanvas/MyCanvas.vue
+++ b/mytestvueapp.client/src/components/MyCanvas/MyCanvas.vue
@@ -25,8 +25,9 @@ onMounted(() => {
     let contextInit = canvasInit.getContext("2d");
     if (contextInit) {
       context.value = contextInit;
-      canvas.value.width = props?.art?.pixelGrid.width * props.pixelSize;
-      canvas.value.height = props.art.pixelGrid.height * props.pixelSize;
+      canvas.value.width = 32 * props.pixelSize;
+      canvas.value.height = 32 * props.pixelSize;
+      context.value.scale(32/props?.art?.pixelGrid.width, 32/props?.art?.pixelGrid.width)
     }
   }
 

--- a/mytestvueapp.client/src/views/GalleryView.vue
+++ b/mytestvueapp.client/src/views/GalleryView.vue
@@ -14,7 +14,7 @@
       </h1>
     </header>
     <div class="shrink-limit flex flex-wrap" v-if="!loading">
-      <ArtCard v-for="art in displayArt" :key="art.id" :art="art" :size="6.5" />
+      <ArtCard v-for="art in displayArt" :key="art.id" :art="art"/>
     </div>
   </div>
 </template>

--- a/mytestvueapp.client/src/views/GalleryView.vue
+++ b/mytestvueapp.client/src/views/GalleryView.vue
@@ -14,7 +14,7 @@
       </h1>
     </header>
     <div class="shrink-limit flex flex-wrap" v-if="!loading">
-      <ArtCard v-for="art in displayArt" :key="art.id" :art="art"/>
+      <ArtCard v-for="art in displayArt" :key="art.id" :art="art" :size="6.5"/>
     </div>
   </div>
 </template>

--- a/mytestvueapp.client/src/views/ImageViewerView.vue
+++ b/mytestvueapp.client/src/views/ImageViewerView.vue
@@ -5,7 +5,7 @@
         v-if="art"
         :key="art.id"
         :art="art"
-        :pixelSize="20 * (32 / art.pixelGrid.width)"
+        :pixelSize="20"
       ></my-canvas>
     </div>
     <Card class="w-20rem ml-5">


### PR DESCRIPTION
Made it so canvases with odd dimensions scale properly. 

Also changed the response IsLiked() gives when called by a user who has never logged in to OK(false), rather than BadRequest() because this endpoint will be called (rightfully) by each like button present when a user without a cookie tries to view a page containing at least one like button. 